### PR TITLE
bugfix: use selected base in utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Jikanpy
 
+## [4.1.0] - 2020-05-23
+
+### Fixed
+
+- Bug where selected_base wasn't being used
+
 ## [4.0.0] - 2020-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ you can pass that to Jikan:
 
 ```python
 from jikanpy import Jikan
-jikan = Jikan(selected_base='http://localhost:8000/v3/')
+jikan = Jikan(selected_base='http://localhost:8000/v3')
 ```
 
 If you want to use your own Requests session, you can do that too.
@@ -120,7 +120,7 @@ from jikanpy import AioJikan
 async def main():
     # Construct AioJikan with own base URL and custom AioHTTP session with custom persistent headers
     session = aiohttp.ClientSession(headers={'x-test': 'true'})
-    aio_jikan = AioJikan(selected_base='http://localhost:8000/v3/', session=session)
+    aio_jikan = AioJikan(selected_base='http://localhost:8000/v3', session=session)
     await session.close()
 
 asyncio.run(main())

--- a/jikanpy/aiojikan.py
+++ b/jikanpy/aiojikan.py
@@ -62,7 +62,7 @@ class AioJikan:
 
         Examples:
             >>> aio_jikan_1 = AioJikan()
-            >>> aio_jikan_2 = AioJikan(selected_base='http://localhost:8000/v3/')
+            >>> aio_jikan_2 = AioJikan(selected_base='http://localhost:8000/v3')
             >>> aio_jikan_3 = AioJikan(session=aiohttp.ClientSession(headers={'x-test': 'true'}))
         """
         self.base = utils.BASE_URL if selected_base is None else selected_base
@@ -114,7 +114,7 @@ class AioJikan:
         anime, manga, character, person, club
         """
         session = await self._get_session()
-        url = utils.get_main_url(endpoint, id, extension, page)
+        url = utils.get_main_url(self.base, endpoint, id, extension, page)
         response: aiohttp.ClientResponse = await session.get(url)
         return await self._wrap_response(response, url, id=id, endpoint=endpoint)
 
@@ -123,7 +123,7 @@ class AioJikan:
     ) -> Dict:
         """Gets the response from Jikan API for producer and magazine"""
         session = await self._get_session()
-        url = utils.get_creator_url(creator_type, creator_id, page)
+        url = utils.get_creator_url(self.base, creator_type, creator_id, page)
         response = await session.get(url)
         return await self._wrap_response(
             response, url, id=creator_id, endpoint=creator_type
@@ -261,7 +261,7 @@ class AioJikan:
             >>> await jikan.search('anime', 'Jojo', page=2, parameters={'genre': 37, 'type': 'tv'})
         """
         session = await self._get_session()
-        url = utils.get_search_url(search_type, query, page, parameters)
+        url = utils.get_search_url(self.base, search_type, query, page, parameters)
         response = await session.get(url)
         kwargs = {"search type": search_type, "query": query}
         return await self._wrap_response(response, url, **kwargs)
@@ -282,7 +282,7 @@ class AioJikan:
             >>> await jikan.season(year=2016, season='spring')
         """
         session = await self._get_session()
-        url = utils.get_season_url(year, season)
+        url = utils.get_season_url(self.base, year, season)
         response = await session.get(url)
         return await self._wrap_response(response, url, year=year, season=season)
 
@@ -295,9 +295,10 @@ class AioJikan:
         Examples:
             >>> await jikan.season_archive()
         """
+        url = utils.get_season_archive_url(self.base)
         session = await self._get_session()
-        response = await session.get(utils.SEASON_ARCHIVE_URL)
-        return await self._wrap_response(response, utils.SEASON_ARCHIVE_URL)
+        response = await session.get(url)
+        return await self._wrap_response(response, url)
 
     async def season_later(self) -> Dict:
         """Gets anime that have been announced for upcoming seasons.
@@ -308,9 +309,10 @@ class AioJikan:
         Examples:
             >>> await jikan.season_later()
         """
+        url = utils.get_season_later_url(self.base)
         session = await self._get_session()
-        response = await session.get(utils.SEASON_LATER_URL)
-        return await self._wrap_response(response, utils.SEASON_LATER_URL)
+        response = await session.get(url)
+        return await self._wrap_response(response, url)
 
     async def schedule(self, day: Optional[str] = None) -> Dict:
         """Gets anime scheduled.
@@ -327,7 +329,7 @@ class AioJikan:
             >>> await jikan.schedule(day='monday')
         """
         session = await self._get_session()
-        url = utils.get_schedule_url(day)
+        url = utils.get_schedule_url(self.base, day)
         response = await session.get(url)
         return await self._wrap_response(response, url, day=day)
 
@@ -353,7 +355,7 @@ class AioJikan:
             >>> await jikan.top(type='anime', page=2, subtype='upcoming')
         """
         session = await self._get_session()
-        url = utils.get_top_url(type, page, subtype)
+        url = utils.get_top_url(self.base, type, page, subtype)
         response = await session.get(url)
         return await self._wrap_response(response, url, type=type)
 
@@ -375,7 +377,7 @@ class AioJikan:
             >>> await jikan.genre(type='manga', genre_id=2)
         """
         session = await self._get_session()
-        url = utils.get_genre_url(type, genre_id, page)
+        url = utils.get_genre_url(self.base, type, genre_id, page)
         response = await session.get(url)
         return await self._wrap_response(response, url, id=genre_id, type=type)
 
@@ -451,7 +453,9 @@ class AioJikan:
             >>> await jikan.user(username='Xinil', request='animelist', argument='ptw', parameters={'page': 2})
         """
         session = await self._get_session()
-        url = utils.get_user_url(username, request, argument, page, parameters)
+        url = utils.get_user_url(
+            self.base, username, request, argument, page, parameters
+        )
         response = await session.get(url)
         return await self._wrap_response(
             response, url, username=username, request=request
@@ -487,7 +491,7 @@ class AioJikan:
             >>> await jikan.meta('status')
         """
         session = await self._get_session()
-        url = utils.get_meta_url(request, type, period, offset)
+        url = utils.get_meta_url(self.base, request, type, period, offset)
         response = await session.get(url)
         return await self._wrap_response(
             response, url, request=request, type=type, period=period

--- a/jikanpy/jikan.py
+++ b/jikanpy/jikan.py
@@ -48,7 +48,7 @@ class Jikan:
 
         Examples:
             >>> jikan_1 = Jikan()
-            >>> jikan_2 = Jikan(selected_base='http://localhost:8000/v3/')
+            >>> jikan_2 = Jikan(selected_base='http://localhost:8000/v3')
             >>> jikan_3 = jikan = Jikan(session=requests.Session())
         """
         self.base = utils.BASE_URL if selected_base is None else selected_base
@@ -84,7 +84,7 @@ class Jikan:
         Gets the response from Jikan API given the endpoint:
         anime, manga, character, person, club
         """
-        url = utils.get_main_url(endpoint, id, extension, page)
+        url = utils.get_main_url(self.base, endpoint, id, extension, page)
         response = self.session.get(url)
         return self._wrap_response(response, url, id=id, endpoint=endpoint)
 
@@ -92,7 +92,7 @@ class Jikan:
         self, creator_type: str, creator_id: int, page: Optional[int] = None
     ) -> Dict:
         """Gets the response from Jikan API for producer and magazine"""
-        url = utils.get_creator_url(creator_type, creator_id, page)
+        url = utils.get_creator_url(self.base, creator_type, creator_id, page)
         response = self.session.get(url)
         return self._wrap_response(response, url, id=creator_id, endpoint=creator_type)
 
@@ -227,7 +227,7 @@ class Jikan:
             >>> jikan.search('anime', 'Jojo', parameters={'type': 'tv'})
             >>> jikan.search('anime', 'Jojo', page=2, parameters={'genre': 37, 'type': 'tv'})
         """
-        url = utils.get_search_url(search_type, query, page, parameters)
+        url = utils.get_search_url(self.base, search_type, query, page, parameters)
         response = self.session.get(url)
         kwargs = {"search type": search_type, "query": query}
         return self._wrap_response(response, url, **kwargs)
@@ -247,7 +247,7 @@ class Jikan:
             >>> jikan.season(year=2018, season='winter')
             >>> jikan.season(year=2016, season='spring')
         """
-        url = utils.get_season_url(year, season)
+        url = utils.get_season_url(self.base, year, season)
         response = self.session.get(url)
         return self._wrap_response(response, url, year=year, season=season)
 
@@ -260,8 +260,9 @@ class Jikan:
         Examples:
             >>> jikan.season_archive()
         """
-        response = self.session.get(utils.SEASON_ARCHIVE_URL)
-        return self._wrap_response(response, utils.SEASON_ARCHIVE_URL)
+        url = utils.get_season_archive_url(self.base)
+        response = self.session.get(url)
+        return self._wrap_response(response, url)
 
     def season_later(self) -> Dict:
         """Gets anime that have been announced for upcoming seasons.
@@ -272,8 +273,9 @@ class Jikan:
         Examples:
             >>> jikan.season_later()
         """
-        response = self.session.get(utils.SEASON_LATER_URL)
-        return self._wrap_response(response, utils.SEASON_LATER_URL)
+        url = utils.get_season_later_url(self.base)
+        response = self.session.get(url)
+        return self._wrap_response(response, url)
 
     def schedule(self, day: Optional[str] = None) -> Dict:
         """Gets anime scheduled.
@@ -289,7 +291,7 @@ class Jikan:
             >>> jikan.schedule()
             >>> jikan.schedule(day='monday')
         """
-        url = utils.get_schedule_url(day)
+        url = utils.get_schedule_url(self.base, day)
         response = self.session.get(url)
         return self._wrap_response(response, url, day=day)
 
@@ -314,7 +316,7 @@ class Jikan:
             >>> jikan.top(type='manga')
             >>> jikan.top(type='anime', page=2, subtype='upcoming')
         """
-        url = utils.get_top_url(type, page, subtype)
+        url = utils.get_top_url(self.base, type, page, subtype)
         response = self.session.get(url)
         return self._wrap_response(response, url, type=type)
 
@@ -335,7 +337,7 @@ class Jikan:
             >>> jikan.genre(type='anime', genre_id=1)
             >>> jikan.genre(type='manga', genre_id=2)
         """
-        url = utils.get_genre_url(type, genre_id, page)
+        url = utils.get_genre_url(self.base, type, genre_id, page)
         response = self.session.get(url)
         return self._wrap_response(response, url, id=genre_id, type=type)
 
@@ -410,7 +412,9 @@ class Jikan:
             >>> jikan.user(username='Xinil', request='animelist', parameters={'page': 2})
             >>> jikan.user(username='Xinil', request='animelist', argument='ptw', parameters={'page': 2})
         """
-        url = utils.get_user_url(username, request, argument, page, parameters)
+        url = utils.get_user_url(
+            self.base, username, request, argument, page, parameters
+        )
         response = self.session.get(url)
         return self._wrap_response(response, url, username=username, request=request)
 
@@ -443,7 +447,7 @@ class Jikan:
             >>> jikan.meta('requests', type='anime', period='today')
             >>> jikan.meta('status')
         """
-        url = utils.get_meta_url(request, type, period, offset)
+        url = utils.get_meta_url(self.base, request, type, period, offset)
         response = self.session.get(url)
         return self._wrap_response(
             response, url, request=request, type=type, period=period

--- a/jikanpy/utils.py
+++ b/jikanpy/utils.py
@@ -6,8 +6,6 @@ import requests
 from jikanpy.exceptions import APIException
 
 BASE_URL = "https://api.jikan.moe/v3"
-SEASON_ARCHIVE_URL = f"{BASE_URL}/season/archive"
-SEASON_LATER_URL = f"{BASE_URL}/season/later"
 
 
 def check_response(
@@ -47,61 +45,75 @@ def get_url_with_page(url: str, page: Optional[int], delimiter: str = "/") -> st
 
 
 def get_main_url(
-    endpoint: str, id: int, extension: Optional[str], page: Optional[int]
+    base_url: str, endpoint: str, id: int, extension: Optional[str], page: Optional[int]
 ) -> str:
     """Create URL for anime, manga, character, person, and club endpoints"""
-    url = f"{BASE_URL}/{endpoint}/{id}"
+    url = f"{base_url}/{endpoint}/{id}"
     if extension is not None:
         url += f"/{extension}"
         url = get_url_with_page(url, page)
     return url
 
 
-def get_creator_url(creator_type: str, creator_id: int, page: Optional[int]) -> str:
+def get_creator_url(
+    base_url: str, creator_type: str, creator_id: int, page: Optional[int]
+) -> str:
     """Create URL for producer and magazine endpoints"""
-    url = f"{BASE_URL}/{creator_type}/{creator_id}"
+    url = f"{base_url}/{creator_type}/{creator_id}"
     return get_url_with_page(url, page)
 
 
 def get_search_url(
+    base_url: str,
     search_type: str,
     query: str,
     page: Optional[int],
     parameters: Optional[Mapping[str, Optional[Union[int, str, float]]]],
 ) -> str:
     """Create URL for search endpoint"""
-    url = f"{BASE_URL}/search/{search_type}?q={query}"
+    url = f"{base_url}/search/{search_type}?q={query}"
     url = get_url_with_page(url, page, delimiter="&page=")
     if parameters is not None:
         url += "".join(f"&{k}={v}" for k, v in parameters.items())
     return url
 
 
-def get_season_url(year: int, season: str) -> str:
+def get_season_url(base_url: str, year: int, season: str) -> str:
     """Create URL for season endpoint"""
-    return f"{BASE_URL}/season/{year}/{season.lower()}"
+    return f"{base_url}/season/{year}/{season.lower()}"
 
 
-def get_schedule_url(day: Optional[str]) -> str:
+def get_schedule_url(base_url: str, day: Optional[str]) -> str:
     """Create URL for schedule endpoint"""
-    base_schedule_url = f"{BASE_URL}/schedule"
+    base_schedule_url = f"{base_url}/schedule"
     return base_schedule_url if day is None else f"{base_schedule_url}/{day.lower()}"
 
 
-def get_top_url(type: str, page: Optional[int], subtype: Optional[str]) -> str:
+def get_season_archive_url(base_url: str) -> str:
+    return f"{base_url}/season/archive"
+
+
+def get_season_later_url(base_url: str) -> str:
+    return f"{base_url}/season/later"
+
+
+def get_top_url(
+    base_url: str, type: str, page: Optional[int], subtype: Optional[str]
+) -> str:
     """Create URL for top endpoint"""
-    url = f"{BASE_URL}/top/{type.lower()}"
+    url = f"{base_url}/top/{type.lower()}"
     url = get_url_with_page(url, page)
     return url if subtype is None else f"{url}/{subtype.lower()}"
 
 
-def get_genre_url(type: str, genre_id: int, page: Optional[int]) -> str:
+def get_genre_url(base_url: str, type: str, genre_id: int, page: Optional[int]) -> str:
     """Create URL for genre endpoint"""
-    url = f"{BASE_URL}/genre/{type.lower()}/{genre_id}"
+    url = f"{base_url}/genre/{type.lower()}/{genre_id}"
     return get_url_with_page(url, page)
 
 
 def get_user_url(
+    base_url: str,
     username: str,
     request: Optional[str],
     argument: Optional[Union[int, str]],
@@ -109,7 +121,7 @@ def get_user_url(
     parameters: Optional[Mapping],
 ) -> str:
     """Create URL for user endpoint"""
-    url = f"{BASE_URL}/user/{username.lower()}"
+    url = f"{base_url}/user/{username.lower()}"
     if request is not None:
         url += f"/{request}"
         if argument is not None:
@@ -122,10 +134,14 @@ def get_user_url(
 
 
 def get_meta_url(
-    request: str, type: Optional[str], period: Optional[str], offset: Optional[int],
+    base_url: str,
+    request: str,
+    type: Optional[str],
+    period: Optional[str],
+    offset: Optional[int],
 ) -> str:
     """Create URL for meta endpoint"""
-    url = f"{BASE_URL}/meta/{request}"
+    url = f"{base_url}/meta/{request}"
     if type is not None and period is not None:
         url += f"/{type}/{period}"
     return get_url_with_page(url, offset)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ CHANGELOG = (HERE / "CHANGELOG.md").read_text()
 
 setup(
     name="jikanpy",
-    version="4.0.0",
+    version="4.1.0",
     description="Python wrapper for the Jikan API",
     license="MIT",
     long_description=README + CHANGELOG,

--- a/tests/test_aiojikan.py
+++ b/tests/test_aiojikan.py
@@ -36,7 +36,9 @@ async def test_construct_using_async_with():
 @vcr.use_cassette("tests/vcr_cassettes/aio-wrap-response.yaml")
 async def test_wrap_response(aio_jikan):
     anime_info = await aio_jikan.anime(MUSHISHI_ID)
-    mushishi_url = utils.get_main_url("anime", MUSHISHI_ID, extension=None, page=None)
+    mushishi_url = utils.get_main_url(
+        aio_jikan.base, "anime", MUSHISHI_ID, extension=None, page=None
+    )
 
     assert isinstance(anime_info, dict)
     assert "jikan_url" in anime_info

--- a/tests/test_jikan.py
+++ b/tests/test_jikan.py
@@ -29,7 +29,9 @@ def jikan():
 @vcr.use_cassette("tests/vcr_cassettes/wrap-response.yaml")
 def test_wrap_response(header_keys, jikan):
     anime_info = jikan.anime(MUSHISHI_ID)
-    mushishi_url = utils.get_main_url("anime", MUSHISHI_ID, extension=None, page=None)
+    mushishi_url = utils.get_main_url(
+        jikan.base, "anime", MUSHISHI_ID, extension=None, page=None
+    )
 
     assert isinstance(anime_info, dict)
     assert "jikan_url" in anime_info
@@ -278,3 +280,11 @@ def test_user_list_failure(jikan):
 def test_empty_response_json(jikan, response_mock):
     with pytest.raises(APIException):
         jikan._wrap_response(response_mock, url="")
+
+
+def test_season_urls(jikan):
+    season_archive_url = utils.get_season_archive_url(jikan.base)
+    season_later_url = utils.get_season_later_url(jikan.base)
+    assert season_archive_url.endswith("season/archive")
+    assert season_later_url.endswith("season/later")
+    assert season_archive_url.startswith(jikan.base)


### PR DESCRIPTION
cant believe it took me 3 days to realize why my jikan requests kept failing, were sending them to remote instead of my local instnace.

4.0.0 had a bug where it used BASE_URL from utils all the time instead of respecting the `self.base` URL from `jikanpy`/`aiojikan`; this fixes that.

I recommend a version bump.

Anyone self hosting should also note that they have to remove the trialing slash from the URL (e.g. `http://localhost:8000/v3/` -> `http://localhost:8000/v3` -- perhaps we should add a `.rstrip('/')` call to just make it backwards compatible. Thoughts?